### PR TITLE
Docker socket requires a Host header now.

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -30,7 +30,7 @@ function setup {
     (
         sleep 1
         if [ `cat /tmp/next` = $NEXT ]; then
-            echo -e "POST /containers/$CONTAINER_ID/kill?signal=$SIGNAL HTTP/1.1\n" | ncat -U /var/run/docker.sock
+            echo -e "POST /containers/$CONTAINER_ID/kill?signal=$SIGNAL HTTP/1.1\nHost: docker.sock\n" | ncat -U /var/run/docker.sock
         fi
     ) &
 }


### PR DESCRIPTION
Before:
> [root@08a1376e161e /]# echo -e "POST /containers/nginx/kill?signal=SIGHUP HTTP/1.1\n" | ncat -U /var/run/docker.sock                                      
> HTTP/1.1 400 Bad Request
> Content-Type: text/plain
> Connection: close
> 
> 400 Bad Request: missing required Host header[root@08a1376e161e /]# 
> [root@08a1376e161e /]# 

After:
> [root@08a1376e161e /]# echo -e "POST /containers/nginx/kill?signal=SIGHUP HTTP/1.1\nHost: docker.sock\n" | ncat -U /var/run/docker.sock
> HTTP/1.1 204 No Content
> Content-Type: application/json
> Server: Docker/1.12.6 (linux)
> Date: Tue, 28 Feb 2017 08:05:26 GMT
> Connection: close
> 
> [root@08a1376e161e /]#